### PR TITLE
allow installation on PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.0",
+        "php": ">=7.1.0 <9.0",
         "symfony/framework-bundle": "~2.8|~3.0|~4.0|~5.0",
         "symfony/form": "~2.8|~3.0|~4.0|~5.0",
         "symfony/property-access": "~2.8|~3.0|~4.0|~5.0"


### PR DESCRIPTION
The current constraints exclude PHP 8 and therefore its not possible to install this bundle without the --ignore-platform-reqs flag.

I did a brief test with auto generation enabled and it seems to work on PHP 8.

Therefore I changed the php requirement to also include PHP 8.